### PR TITLE
added urldecode() when the query is rendered

### DIFF
--- a/debug/views/detail.php
+++ b/debug/views/detail.php
@@ -61,7 +61,7 @@ echo GridView::widget([
         [
             'attribute' => 'request',
             'value' => function ($data) {
-                $query = Html::encode($data['request']);
+                $query = Html::encode(urldecode($data['request']));
 
                 if (!empty($data['trace'])) {
                     $query .= Html::ul($data['trace'], [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | 

```
GET http://api.local/custom-field?q=%7B%22where%22%3A%7B%22field_id%22%3A13%2C%22context%22%3A%22cerberusweb.contexts.org%22%7D%7D
```
VS
```
GET http://api.local/custom-field?q={"where":{"field_id":13,"context":"cerberusweb.contexts.org"}}
```
