### PR TITLE
Added `XmlFormatter::removeDeclaration` allowing remove XML declaration which is not required in all XML documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 HTTP client extension Change Log
 2.0.4 under development
 -----------------------
 
+- Enh: Added `XmlFormatter::removeDeclaration` allowing remove XML declaration which is not required in all XML documents (yyxx9988)
 - Bug #94: Fixed `XmlParser` does not respects character encoding from response headers (klimov-paul)
 
 

--- a/tests/XmlFormatterTest.php
+++ b/tests/XmlFormatterTest.php
@@ -96,6 +96,36 @@ XML;
     /**
      * @depends testFormat
      */
+    public function testFormatDeclaration()
+    {
+        $request = new Request();
+        $data = [
+            'name1' => 'value1',
+            'name2' => 'value2',
+        ];
+        $request->setData($data);
+
+        $formatter = new XmlFormatter();
+
+        $formatter->removeDeclaration = false;
+        $formatter->format($request);
+        $expectedContent = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<request><name1>value1</name1><name2>value2</name2></request>
+XML;
+        $this->assertEqualsWithoutLE($expectedContent, $request->getContent());
+
+        $formatter->removeDeclaration = true;
+        $formatter->format($request);
+        $expectedContent = <<<XML
+<request><name1>value1</name1><name2>value2</name2></request>
+XML;
+        $this->assertEqualsWithoutLE($expectedContent, $request->getContent());
+    }
+
+    /**
+     * @depends testFormat
+     */
     public function testFormatFromDom()
     {
         $request = new Request();


### PR DESCRIPTION
The XML declaration describes some of the most general properties of the document, but it is not required in all XML documents.