### PR TITLE
Fix bug when json return in Reason Phrase

### DIFF
--- a/Message.php
+++ b/Message.php
@@ -82,13 +82,14 @@ class Message extends Component
                     if (is_int($name)) {
                         // parse raw header :
                         $rawHeader = $value;
-                        if (($separatorPos = strpos($rawHeader, ':')) !== false) {
+
+                        if (strpos($rawHeader, 'HTTP/') === 0) {
+                            $parts = explode(' ', $rawHeader, 3);
+                            $headerCollection->add('http-code', $parts[1]);
+                        } elseif (($separatorPos = strpos($rawHeader, ':')) !== false) {
                             $name = strtolower(trim(substr($rawHeader, 0, $separatorPos)));
                             $value = trim(substr($rawHeader, $separatorPos + 1));
                             $headerCollection->add($name, $value);
-                        } elseif (strpos($rawHeader, 'HTTP/') === 0) {
-                            $parts = explode(' ', $rawHeader, 3);
-                            $headerCollection->add('http-code', $parts[1]);
                         } else {
                             $headerCollection->add('raw', $rawHeader);
                         }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "yiisoft/yii2-httpclient",
+    "name": "lan143/yii2-httpclient",
     "description": "HTTP client extension for the Yii framework",
     "keywords": ["yii2", "http", "httpclient", "curl"],
     "type": "yii2-extension",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "lan143/yii2-httpclient",
+    "name": "yiisoft/yii2-httpclient",
     "description": "HTTP client extension for the Yii framework",
     "keywords": ["yii2", "http", "httpclient", "curl"],
     "type": "yii2-extension",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | Yes
| New feature?  | No
| Breaks BC?    | No
| Tests pass?   | Yes
| Fixed issues  | 

Example http start string: HTTP/1.0 400 {"subscription_id":["Subscription Id \"86457\" is invalid."]}

Exception:
`2017-11-13 12:08:45 [192.168.33.1][3][rneqkkh6efi4slp61crsgqur07][error][yii\httpclient\Exception] exception 'yii\httpclient\Exception' with message 'Unable to get status code: referred header information is missing.' in /vagrant_data/erp-api/vendor/yiisoft/yii2-httpclient/Response.php:68
Stack trace:
#0 /vagrant_data/erp-api/common/manage/ManageApiv3Client.php(341): yii\httpclient\Response->getStatusCode()
#1 /vagrant_data/erp-api/common/manage/ManageApiv3Client.php(142): common\manage\ManageApiv3Client->sendRequest('post', 'subscription', Array, Array)
#2 /vagrant_data/erp-api/frontend/modules/v1/controllers/OrderController.php(325): common\manage\ManageApiv3Client->createSubscription(Object(frontend\modules\v1\models\Checkout))
#3 [internal function]: frontend\modules\v1\controllers\OrderController->actionCreate()
#4 /vagrant_data/erp-api/vendor/yiisoft/yii2/base/InlineAction.php(57): call_user_func_array(Array, Array)
#5 /vagrant_data/erp-api/vendor/yiisoft/yii2/base/Controller.php(156): yii\base\InlineAction->runWithParams(Array)
#6 /vagrant_data/erp-api/vendor/yiisoft/yii2/base/Module.php(523): yii\base\Controller->runAction('create', Array)
#7 /vagrant_data/erp-api/vendor/yiisoft/yii2/web/Application.php(102): yii\base\Module->runAction('v1/order/create', Array)
#8 /vagrant_data/erp-api/vendor/yiisoft/yii2/base/Application.php(380): yii\web\Application->handleRequest(Object(yii\web\Request))
#9 /vagrant_data/erp-api/frontend/web/index.php(18): yii\base\Application->run()
#10 {main}`