### PR TITLE
fixed by nash-x9

### DIFF
--- a/StreamTransport.php
+++ b/StreamTransport.php
@@ -61,7 +61,7 @@ class StreamTransport extends Transport
             $stream = fopen($url, 'rb', false, $context);
             $responseContent = stream_get_contents($stream);
             // see http://php.net/manual/en/reserved.variables.httpresponseheader.php
-            $responseHeaders = $http_response_header;
+            $responseHeaders = $http_response_header??array();
             fclose($stream);
         } catch (\Exception $e) {
             Yii::endProfile($token, __METHOD__);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Tests pass?   | yes
| Fixed issues  |  # 1.fixed when use curl to connect a not exist port,it will throw these:
Argument 2 passed to yii\\httpclient\\Client::createResponse() must be of the type array, null given, called in /data/www/tiku_tl/vendor/yiisoft/yii2-httpclient/StreamTransport.php on line 73
