### PR TITLE
get the wrong full url

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -303,7 +303,7 @@ class Request extends Message
             if (empty($url)) {
                 $url = $this->client->baseUrl;
             } elseif (!preg_match('/^https?:\\/\\//i', $url)) {
-                $url = $this->client->baseUrl . '/' . $url;
+                $url = rtrim($this->client->baseUrl, '/') . '/' . ltrim($url, '/');
             }
         }
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -208,6 +208,21 @@ EOL;
                 ['param1' => 'name1'],
                 'http://some-domain.com?base-param=base&param1=name1',
             ],
+            [
+                'http://some-domain.com/',
+                '/test/url',
+                'http://some-domain.com/test/url'
+            ],
+            [
+                'http://some-domain.com/',
+                'test/url',
+                'http://some-domain.com/test/url'
+            ],
+            [
+                'http://some-domain.com',
+                '/test/url',
+                'http://some-domain.com/test/url'
+            ],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  |


```php
$client = new Client(['baseUrl' =>'http://example.com/']);
$request = $client->createRequest();
$request->setUrl('/site/index');
echo $request->getFullUrl();
```
**Expect**

```
http://example.com/site/index
```

**But**
```
http://example.com///site/index
```