### PR TITLE
$http_response_header can return NULL

### DIFF
--- a/src/StreamTransport.php
+++ b/src/StreamTransport.php
@@ -61,7 +61,7 @@ class StreamTransport extends Transport
             $stream = fopen($url, 'rb', false, $context);
             $responseContent = stream_get_contents($stream);
             // see http://php.net/manual/en/reserved.variables.httpresponseheader.php
-            $responseHeaders = $http_response_header;
+            $responseHeaders = $http_response_header !== null ? $http_response_header : [];
             fclose($stream);
         } catch (\Exception $e) {
             Yii::endProfile($token, __METHOD__);


### PR DESCRIPTION
The variable $http_response_header can return null (if I don't use headers or it return an error), so it is necessary to change it to empty array, because createResponse($content = null, array $headers = []).

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #138
