### PR TITLE
`Response::detectFormatByContent` falsely detected HTML as XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 HTTP client extension Change Log
 2.0.8 under development
 -----------------------
 
-- no changes in this release.
+- Bug #168: `Response::detectFormatByContent` falsely detected HTML as XML (CeBe)
 
 
 2.0.7 September 24, 2018

--- a/src/Response.php
+++ b/src/Response.php
@@ -130,7 +130,7 @@ class Response extends Message
         if (preg_match('/^([^=&])+=[^=&]+(&[^=&]+=[^=&]+)*$/', $content)) {
             return Client::FORMAT_URLENCODED;
         }
-        if (preg_match('/^<.*>$/s', $content)) {
+        if (preg_match('/^<\?xml.*>$/s', $content)) {
             return Client::FORMAT_XML;
         }
         return null;

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -87,6 +87,17 @@ class ResponseTest extends TestCase
                 'some-plain-string',
                 null
             ],
+            [   // do not detect HTML as XML
+                <<<HTML
+<!DOCTYPE html>
+<html>
+<head><title>Some title</title></head>
+<body>some text</body>
+</html>
+HTML
+                ,
+                null
+            ],
         ];
     }
 


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | fixes #168
