### PR TITLE
Allow configuring `JsonParser` to parse JSON as objects instead of arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 HTTP client extension Change Log
 2.0.8 under development
 -----------------------
 
-- no changes in this release.
+- Enh #153: Allow configuring `JsonParser` to parse JSON as objects instead of arrays (CeBe)
 
 
 2.0.7 September 24, 2018

--- a/docs/guide/usage-data-formats.md
+++ b/docs/guide/usage-data-formats.md
@@ -27,6 +27,13 @@ $client = new Client([
         'myformat' => 'app\components\http\MyFormatter', // add new formatter
         Client::FORMAT_XML => 'app\components\http\MyXMLFormatter', // override default XML formatter
     ],
+    'parsers' => [
+        // configure options of the JsonParser, parse JSON as objects
+        Client::FORMAT_JSON => [
+            'class' => 'yii\httpclient\JsonParser',
+            'asArray' => false,
+        ]
+    ],
 ]);
 ```
 

--- a/src/JsonParser.php
+++ b/src/JsonParser.php
@@ -19,10 +19,17 @@ use yii\helpers\Json;
 class JsonParser extends BaseObject implements ParserInterface
 {
     /**
+     * @var bool whether to return objects in terms of associative arrays.
+     * @since 2.0.8
+     */
+    public $asArray = true;
+
+
+    /**
      * {@inheritdoc}
      */
     public function parse(Response $response)
     {
-        return Json::decode($response->getContent());
+        return Json::decode($response->getContent(), $this->asArray);
     }
 }

--- a/tests/JsonParserTest.php
+++ b/tests/JsonParserTest.php
@@ -21,6 +21,20 @@ class JsonParserTest extends TestCase
         $this->assertEquals($data, $parser->parse($document));
     }
 
+    public function testParseAsObject()
+    {
+        $document = new Response();
+        $data = new \stdClass();
+        $data->name1 = 'value1';
+        $data->name2 = 'value2';
+        $document->setContent(Json::encode($data));
+
+        $parser = new JsonParser([
+            'asArray' => false,
+        ]);
+        $this->assertEquals($data, $parser->parse($document));
+    }
+
     public function testParse2()
     {
         $document = new Response();


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes 
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | fixes #153
