### PR TITLE
Closes #178. Fix failed test.

### DIFF
--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -320,41 +320,41 @@ EOL;
         $boundary = $matches[1];
         $parts = explode("--$boundary", $requestString);
         $this->assertCount(6, $parts);
-        $this->assertEquals(str_replace(PHP_EOL, "\r\n", <<<PART1
+        $expectedPart1 = <<<PART1
 
 Content-Disposition: form-data; name="data1"
 
 data1=123
 
-PART1
-        ), $parts[1]);
-        $this->assertEquals(str_replace(PHP_EOL, "\r\n", <<<PART2
+PART1;
+        $this->assertEquals(str_replace("\r", '', $expectedPart1), str_replace("\r", '', $parts[1]));
+        $expectedPart2 = <<<PART2
 
 Content-Disposition: form-data; name="data2"
 Content-Type: text/plain
 
 data2=456
 
-PART2
-        ), $parts[2]);
-        $this->assertEquals(str_replace(PHP_EOL, "\r\n", <<<PART2
+PART2;
+        $this->assertEquals(str_replace("\r", '', $expectedPart2), str_replace("\r", '', $parts[2]));
+        $expectedPart3 = <<<PART3
 
 Content-Disposition: form-data; name="data3"; filename="file1.txt"
 Content-Type: application/octet-stream
 
 file1
 
-PART2
-        ), $parts[3]);
-        $this->assertEquals(str_replace(PHP_EOL, "\r\n", <<<PART2
+PART3;
+        $this->assertEquals(str_replace("\r", '', $expectedPart3), str_replace("\r", '', $parts[3]));
+        $expectedPart4 = <<<PART4
 
 Content-Disposition: form-data; name="data4"; filename="file2.txt"
 Content-Type: text/plain
 
 file2
 
-PART2
-        ), $parts[4]);
+PART4;
+        $this->assertEquals(str_replace("\r", '', $expectedPart4), str_replace("\r", '', $parts[4]));
     }
 
     /**

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -327,7 +327,7 @@ Content-Disposition: form-data; name="data1"
 data1=123
 
 PART1;
-        $this->assertEquals(str_replace("\r", '', $expectedPart1), str_replace("\r", '', $parts[1]));
+        $this->assertEqualsWithoutLE($expectedPart1, $parts[1]);
         $expectedPart2 = <<<PART2
 
 Content-Disposition: form-data; name="data2"
@@ -336,7 +336,7 @@ Content-Type: text/plain
 data2=456
 
 PART2;
-        $this->assertEquals(str_replace("\r", '', $expectedPart2), str_replace("\r", '', $parts[2]));
+        $this->assertEqualsWithoutLE($expectedPart2, $parts[2]);
         $expectedPart3 = <<<PART3
 
 Content-Disposition: form-data; name="data3"; filename="file1.txt"
@@ -345,7 +345,7 @@ Content-Type: application/octet-stream
 file1
 
 PART3;
-        $this->assertEquals(str_replace("\r", '', $expectedPart3), str_replace("\r", '', $parts[3]));
+        $this->assertEqualsWithoutLE($expectedPart3, $parts[3]);
         $expectedPart4 = <<<PART4
 
 Content-Disposition: form-data; name="data4"; filename="file2.txt"
@@ -354,7 +354,7 @@ Content-Type: text/plain
 file2
 
 PART4;
-        $this->assertEquals(str_replace("\r", '', $expectedPart4), str_replace("\r", '', $parts[4]));
+        $this->assertEqualsWithoutLE($expectedPart4, $parts[4]);
     }
 
     /**


### PR DESCRIPTION
Remove '\r' from both compared strings instead of replacing PHP_EOL with '\r\n'.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #178
