### PR TITLE
Closes #171. Add "Content-Length: 0" header when sending request with…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 HTTP client extension Change Log
 2.0.9 under development
 -----------------------
 
-- no changes in this release.
+- Bug #171: Add "Content-Length: 0" header when sending request with empty body (alexkart)
 
 
 2.0.8 April 16, 2019

--- a/src/CurlTransport.php
+++ b/src/CurlTransport.php
@@ -141,12 +141,10 @@ class CurlTransport extends Transport
         }
 
         $content = $request->getContent();
-        if ($content === null) {
-            if ($method === 'HEAD') {
-                $curlOptions[CURLOPT_NOBODY] = true;
-            }
-        } else {
-            $curlOptions[CURLOPT_POSTFIELDS] = $content;
+        $curlOptions[CURLOPT_POSTFIELDS] = $content;
+
+        if ($method === 'HEAD') {
+            $curlOptions[CURLOPT_NOBODY] = true;
         }
 
         $curlOptions[CURLOPT_RETURNTRANSFER] = true;

--- a/src/CurlTransport.php
+++ b/src/CurlTransport.php
@@ -141,10 +141,11 @@ class CurlTransport extends Transport
         }
 
         $content = $request->getContent();
-        $curlOptions[CURLOPT_POSTFIELDS] = $content;
 
         if ($method === 'HEAD') {
             $curlOptions[CURLOPT_NOBODY] = true;
+        } else {
+            $curlOptions[CURLOPT_POSTFIELDS] = $content;
         }
 
         $curlOptions[CURLOPT_RETURNTRANSFER] = true;

--- a/src/UrlEncodedFormatter.php
+++ b/src/UrlEncodedFormatter.php
@@ -60,6 +60,8 @@ class UrlEncodedFormatter extends BaseObject implements FormatterInterface
 
         if (isset($content)) {
             $request->setContent($content);
+        } else {
+            $request->getHeaders()->set('Content-Length', '0');
         }
 
         return $request;

--- a/tests/CurlTransportTest.php
+++ b/tests/CurlTransportTest.php
@@ -62,4 +62,30 @@ class CurlTransportTest extends TransportTestCase
         ];
         $this->assertEquals($expectedContextOptions, $contextOptions);
     }
+
+    public function testPreparePostRequestWithEmptyBody()
+    {
+        $client = new Client([
+            'transport' => 'yii\httpclient\CurlTransport',
+        ]);
+        $request = $client->createRequest();
+        $request->setMethod('POST');
+        $request->setUrl('http://app.test/full/url');
+
+        $transport = $this->createClient()->getTransport();
+        $curlOptions = $this->invoke($transport, 'prepare', [$request]);
+
+        $expectedCurlOptions = [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => null,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_URL => 'http://app.test/full/url',
+            CURLOPT_HTTPHEADER => [
+                0 => 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8',
+                1 => 'Content-Length: 0',
+            ],
+        ];
+
+        $this->assertEquals($expectedCurlOptions, $curlOptions);
+    }
 }

--- a/tests/CurlTransportTest.php
+++ b/tests/CurlTransportTest.php
@@ -89,4 +89,30 @@ class CurlTransportTest extends TransportTestCase
 
         $this->assertEquals($expectedCurlOptions, $curlOptions);
     }
+
+    public function testPrepareHeadRequestShouldNotHaveBody()
+    {
+        $client = new Client([
+            'transport' => 'yii\httpclient\CurlTransport',
+        ]);
+        $request = $client->createRequest();
+        $request->setMethod('HEAD');
+        $request->setUrl('http://app.test/full/url');
+
+        $transport = $this->createClient()->getTransport();
+        $curlOptions = $this->invoke($transport, 'prepare', [$request]);
+
+        $expectedCurlOptions = [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_URL => 'http://app.test/full/url',
+            CURLOPT_HTTPHEADER => [
+                0 => 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8',
+                1 => 'Content-Length: 0',
+            ],
+            CURLOPT_CUSTOMREQUEST => 'HEAD',
+            CURLOPT_NOBODY => true,
+        ];
+
+        $this->assertEquals($expectedCurlOptions, $curlOptions);
+    }
 }

--- a/tests/CurlTransportTest.php
+++ b/tests/CurlTransportTest.php
@@ -2,6 +2,7 @@
 
 namespace yiiunit\extensions\httpclient;
 
+use yii\httpclient\Client;
 use yii\httpclient\CurlTransport;
 
 /**

--- a/tests/UrlEncodedFormatterTest.php
+++ b/tests/UrlEncodedFormatterTest.php
@@ -2,8 +2,8 @@
 
 namespace yiiunit\extensions\httpclient;
 
-use yii\httpclient\UrlEncodedFormatter;
 use yii\httpclient\Request;
+use yii\httpclient\UrlEncodedFormatter;
 
 class UrlEncodedFormatterTest extends TestCase
 {
@@ -61,5 +61,18 @@ class UrlEncodedFormatterTest extends TestCase
         $formatter = new UrlEncodedFormatter();
         $formatter->format($request);
         $this->assertNull($request->getContent());
+    }
+
+    public function testFormatPostRequestWithEmptyBody()
+    {
+        $request = new Request();
+        $request->setMethod('POST');
+
+        $formatter = new UrlEncodedFormatter();
+        $formatter->format($request);
+
+        $headers = $request->getHeaders();
+
+        $this->assertEquals('0', $headers['content-length'][0]);
     }
 }


### PR DESCRIPTION
Add "Content-Length: 0" header when sending a request with empty post body.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #171 
