### PR TITLE
Closes #149. Fix type error when creating response with headers param…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 HTTP client extension Change Log
 2.0.9 under development
 -----------------------
 
-- no changes in this release.
+- Bug #149: Fix type error in `StreamTransport` when `$http_response_header = null` (alexkart)
 
 
 2.0.8 April 16, 2019

--- a/src/Client.php
+++ b/src/Client.php
@@ -202,8 +202,9 @@ class Client extends Component
      * @return Response request instance.
      * @throws \yii\base\InvalidConfigException
      */
-    public function createResponse($content = null, array $headers = [])
+    public function createResponse($content = null, $headers = null)
     {
+        $headers = (array) $headers;
         $config = $this->responseConfig;
         if (!isset($config['class'])) {
             $config['class'] = Response::className();

--- a/src/Client.php
+++ b/src/Client.php
@@ -202,9 +202,8 @@ class Client extends Component
      * @return Response request instance.
      * @throws \yii\base\InvalidConfigException
      */
-    public function createResponse($content = null, $headers = null)
+    public function createResponse($content = null, array $headers = [])
     {
-        $headers = (array) $headers;
         $config = $this->responseConfig;
         if (!isset($config['class'])) {
             $config['class'] = Response::className();

--- a/src/StreamTransport.php
+++ b/src/StreamTransport.php
@@ -7,9 +7,9 @@
 
 namespace yii\httpclient;
 
+use Yii;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Inflector;
-use Yii;
 
 /**
  * StreamTransport sends HTTP messages using [Streams](http://php.net/manual/en/book.stream.php)
@@ -61,7 +61,7 @@ class StreamTransport extends Transport
             $stream = fopen($url, 'rb', false, $context);
             $responseContent = stream_get_contents($stream);
             // see http://php.net/manual/en/reserved.variables.httpresponseheader.php
-            $responseHeaders = $http_response_header;
+            $responseHeaders = (array)$http_response_header;
             fclose($stream);
         } catch (\Exception $e) {
             Yii::endProfile($token, __METHOD__);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -3,16 +3,17 @@
 namespace yiiunit\extensions\httpclient;
 
 use yii\httpclient\Client;
+use yii\httpclient\CurlTransport;
 use yii\httpclient\JsonFormatter;
-use yii\httpclient\UrlEncodedFormatter;
-use yii\httpclient\XmlFormatter;
 use yii\httpclient\JsonParser;
-use yii\httpclient\UrlEncodedParser;
-use yii\httpclient\XmlParser;
 use yii\httpclient\Request;
 use yii\httpclient\Response;
 use yii\httpclient\Transport;
-use yii\httpclient\CurlTransport;
+use yii\httpclient\UrlEncodedFormatter;
+use yii\httpclient\UrlEncodedParser;
+use yii\httpclient\XmlFormatter;
+use yii\httpclient\XmlParser;
+use yii\web\HeaderCollection;
 
 class ClientTest extends TestCase
 {
@@ -193,4 +194,24 @@ class ClientTest extends TestCase
         $this->assertEquals($responseFormat, $response->getFormat());
         $this->assertEquals($responseContent, $response->getContent());
     }
-} 
+
+    public function testCreateResponseWithHeadersEqualToNull()
+    {
+        $client = new Client();
+        $response = $client->createResponse('content', null);
+        $headersCollection = $response->getHeaders();
+        $this->assertInstanceOf( Response::class, $response);
+        $this->assertInstanceOf(HeaderCollection::class, $headersCollection);
+        $this->assertEquals([], $headersCollection->toArray());
+    }
+
+    public function testCreateResponseWithHeadersEqualToEmptyArray()
+    {
+        $client = new Client();
+        $response = $client->createResponse('content', []);
+        $headersCollection = $response->getHeaders();
+        $this->assertInstanceOf( Response::class, $response);
+        $this->assertInstanceOf(HeaderCollection::class, $headersCollection);
+        $this->assertEquals([], $headersCollection->toArray());
+    }
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -195,23 +195,13 @@ class ClientTest extends TestCase
         $this->assertEquals($responseContent, $response->getContent());
     }
 
-    public function testCreateResponseWithHeadersEqualToNull()
-    {
-        $client = new Client();
-        $response = $client->createResponse('content', null);
-        $headersCollection = $response->getHeaders();
-        $this->assertTrue($response instanceof Response);
-        $this->assertTrue($headersCollection instanceof HeaderCollection);
-        $this->assertEquals([], $headersCollection->toArray());
-    }
-
     public function testCreateResponseWithHeadersEqualToEmptyArray()
     {
         $client = new Client();
         $response = $client->createResponse('content', []);
         $headersCollection = $response->getHeaders();
-        $this->assertTrue($response instanceof Response);
-        $this->assertTrue($headersCollection instanceof HeaderCollection);
+        $this->assertInstanceOf(Response::className(), $response);
+        $this->assertInstanceOf(HeaderCollection::className(), $headersCollection);
         $this->assertEquals([], $headersCollection->toArray());
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -200,8 +200,8 @@ class ClientTest extends TestCase
         $client = new Client();
         $response = $client->createResponse('content', null);
         $headersCollection = $response->getHeaders();
-        $this->assertInstanceOf( Response::class, $response);
-        $this->assertInstanceOf(HeaderCollection::class, $headersCollection);
+        $this->assertTrue($response instanceof Response);
+        $this->assertTrue($headersCollection instanceof HeaderCollection);
         $this->assertEquals([], $headersCollection->toArray());
     }
 
@@ -210,8 +210,8 @@ class ClientTest extends TestCase
         $client = new Client();
         $response = $client->createResponse('content', []);
         $headersCollection = $response->getHeaders();
-        $this->assertInstanceOf( Response::class, $response);
-        $this->assertInstanceOf(HeaderCollection::class, $headersCollection);
+        $this->assertTrue($response instanceof Response);
+        $this->assertTrue($headersCollection instanceof HeaderCollection);
         $this->assertEquals([], $headersCollection->toArray());
     }
 }


### PR DESCRIPTION
Fix type error when creating a response with headers param equals to null.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #149
