### PR TITLE
Closes #66. Add CURLOPT_FILE option support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ Yii Framework 2 HTTP client extension Change Log
 2.0.9 under development
 -----------------------
 
-- Bug #171: Add "Content-Length: 0" header when sending request with empty body (alexkart)
-- Bug #149: Fix type error in `StreamTransport` when `$http_response_header = null` (alexkart)
+- Bug #171: Added "Content-Length: 0" header when sending request with empty body (alexkart)
+- Bug #149: Fixed type error in `StreamTransport` when `$http_response_header = null` (alexkart)
+- Enh #66: Added `CURLOPT_FILE` option support to `CurlTransport` (alexkart)
 
 
 2.0.8 April 16, 2019

--- a/docs/guide/basic-usage.md
+++ b/docs/guide/basic-usage.md
@@ -235,7 +235,7 @@ $client->post('account/profile', ['birthDate' => '10/11/1982'])
 
 You can download a file without loading entire file content into memory (it is especially useful for big files). 
 Use `setOutputFile()` method to pass a stream resource (using `fopen()`, for example) to the request object. It will be 
-passed to the `CURLOPT_FILE` CURL option.
+passed to the `CURLOPT_FILE` cURL option.
 
 ```php
 use yii\httpclient\Client;

--- a/docs/guide/basic-usage.md
+++ b/docs/guide/basic-usage.md
@@ -230,3 +230,23 @@ $client->post('account/profile', ['birthDate' => '10/11/1982'])
     ->setCookies($loginResponse->cookies) // transfer response cookies to request
     ->send();
 ```
+
+## Downloading files using `CurlTransport`
+
+You can download a file without loading entire file content into memory (it is especially useful for big files). 
+Use `setOutputFile()` method to pass a stream resource (using `fopen()`, for example) to the request object. It will be 
+passed to the `CURLOPT_FILE` CURL option.
+
+```php
+use yii\httpclient\Client;
+
+$fh = fopen('/path/to/local/file', 'w');
+$client = new Client([
+    'transport' => 'yii\httpclient\CurlTransport'
+]);
+$response = $client->createRequest()
+    ->setMethod('GET')
+    ->setUrl('http://example.com/path/to/remote/file')
+    ->setOutputFile($fh)
+    ->send();
+```  

--- a/docs/guide/basic-usage.md
+++ b/docs/guide/basic-usage.md
@@ -233,7 +233,7 @@ $client->post('account/profile', ['birthDate' => '10/11/1982'])
 
 ## Downloading files using `CurlTransport`
 
-You can download a file without loading entire file content into memory (it is especially useful for big files). 
+You can download a file without loading its entire content into memory (it is especially useful for big files). 
 Use `setOutputFile()` method to pass a stream resource (using `fopen()`, for example) to the request object. It will be 
 passed to the `CURLOPT_FILE` cURL option.
 

--- a/src/CurlTransport.php
+++ b/src/CurlTransport.php
@@ -152,8 +152,8 @@ class CurlTransport extends Transport
         $curlOptions[CURLOPT_URL] = $request->getFullUrl();
         $curlOptions[CURLOPT_HTTPHEADER] = $request->composeHeaderLines();
 
-        if ($request->getFile()) {
-            $curlOptions[CURLOPT_FILE] = $request->getFile();
+        if ($request->getOutputFile()) {
+            $curlOptions[CURLOPT_FILE] = $request->getOutputFile();
         }
 
         return $curlOptions;

--- a/src/CurlTransport.php
+++ b/src/CurlTransport.php
@@ -152,6 +152,10 @@ class CurlTransport extends Transport
         $curlOptions[CURLOPT_URL] = $request->getFullUrl();
         $curlOptions[CURLOPT_HTTPHEADER] = $request->composeHeaderLines();
 
+        if ($request->getFile()) {
+            $curlOptions[CURLOPT_FILE] = $request->getFile();
+        }
+
         return $curlOptions;
     }
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -501,7 +501,9 @@ class Request extends Message
     }
 
     /**
+     * Gets the outputFile property
      * @return resource
+     * @since 2.0.9
      */
     public function getOutputFile()
     {
@@ -509,7 +511,10 @@ class Request extends Message
     }
 
     /**
+     * Used with [[CurlTransport]] to set the file that the transfer should be written to
+     * @see CURLOPT_FILE
      * @param resource $file
+     * @since 2.0.9
      */
     public function setOutputFile($file)
     {

--- a/src/Request.php
+++ b/src/Request.php
@@ -54,6 +54,11 @@ class Request extends Message
      */
     private $isPrepared = false;
 
+    /**
+     * @var resource
+     */
+    private $_file;
+
 
     /**
      * Sets target URL.
@@ -493,5 +498,21 @@ class Request extends Message
     private function getFormatter()
     {
         return $this->client->getFormatter($this->getFormat());
+    }
+
+    /**
+     * @return resource
+     */
+    public function getFile()
+    {
+        return $this->_file;
+    }
+
+    /**
+     * @param resource $file
+     */
+    public function setFile($file)
+    {
+        $this->_file = $file;
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -55,9 +55,9 @@ class Request extends Message
     private $isPrepared = false;
 
     /**
-     * @var resource
+     * @var resource The file that the transfer should be written to.
      */
-    private $_file;
+    private $_outputFile;
 
 
     /**
@@ -503,16 +503,16 @@ class Request extends Message
     /**
      * @return resource
      */
-    public function getFile()
+    public function getOutputFile()
     {
-        return $this->_file;
+        return $this->_outputFile;
     }
 
     /**
      * @param resource $file
      */
-    public function setFile($file)
+    public function setOutputFile($file)
     {
-        $this->_file = $file;
+        $this->_outputFile = $file;
     }
 }

--- a/tests/CurlTransportTest.php
+++ b/tests/CurlTransportTest.php
@@ -115,4 +115,29 @@ class CurlTransportTest extends TransportTestCase
 
         $this->assertEquals($expectedCurlOptions, $curlOptions);
     }
+
+    public function testPrepareGetRequestWithOutputFile()
+    {
+        $client = new Client([
+            'transport' => 'yii\httpclient\CurlTransport',
+        ]);
+        $request = $client->createRequest();
+        $request->setMethod('GET');
+        $request->setUrl('http://app.test/full/url');
+        $request->setOutputFile('file_handle');
+
+        $transport = $this->createClient()->getTransport();
+        $curlOptions = $this->invoke($transport, 'prepare', [$request]);
+
+        $expectedCurlOptions = [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_URL => 'http://app.test/full/url',
+            CURLOPT_HTTPHEADER => [],
+            CURLOPT_CUSTOMREQUEST => 'GET',
+            CURLOPT_POSTFIELDS => null,
+            CURLOPT_FILE => 'file_handle'
+        ];
+
+        $this->assertEquals($expectedCurlOptions, $curlOptions);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #66 

This feature is quite simple to implement. I'll also add tests later.
Work still in progress and I need an opinion about the interface. How to name the method? I've just named it `setFile()` for now.
```php
$fh = fopen('path/to/file.png', 'w');
$request->setMethod('GET')
            ->setUrl('http://path/to/file.png')
            ->setFile($fh);
```
Also, do we need to accept only `$fh` of resource type or string as well and if string (path to file) is passed instead of file handler open a file with this path?