### PR TITLE
Closes #189. Fix Content-Length header when using CURLOPT_INFILE option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 HTTP client extension Change Log
 2.0.11 under development
 ------------------------
 
-- no changes in this release.
+- Bug #189: Fixed Content-Length header when using `CURLOPT_INFILE` option (alexkart)
 
 
 2.0.10 April 30, 2019

--- a/src/CurlTransport.php
+++ b/src/CurlTransport.php
@@ -144,7 +144,9 @@ class CurlTransport extends Transport
 
         if ($method === 'HEAD') {
             $curlOptions[CURLOPT_NOBODY] = true;
-        } else {
+        }
+
+        if ($content !== null) {
             $curlOptions[CURLOPT_POSTFIELDS] = $content;
         }
 

--- a/src/UrlEncodedFormatter.php
+++ b/src/UrlEncodedFormatter.php
@@ -60,7 +60,9 @@ class UrlEncodedFormatter extends BaseObject implements FormatterInterface
 
         if (isset($content)) {
             $request->setContent($content);
-        } else {
+        }
+
+        if (!isset($content) && !isset($request->getOptions()[CURLOPT_INFILE])) {
             $request->getHeaders()->set('Content-Length', '0');
         }
 

--- a/tests/CurlTransportTest.php
+++ b/tests/CurlTransportTest.php
@@ -78,7 +78,6 @@ class CurlTransportTest extends TransportTestCase
 
         $expectedCurlOptions = [
             CURLOPT_POST => true,
-            CURLOPT_POSTFIELDS => null,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_URL => 'http://app.test/full/url',
             CURLOPT_HTTPHEADER => [
@@ -107,7 +106,6 @@ class CurlTransportTest extends TransportTestCase
         $curlOptions = $this->invoke($transport, 'prepare', [$request]);
 
         $expectedCurlOptions = [
-            CURLOPT_POSTFIELDS => null,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_URL => 'http://app.test/full/url',
             CURLOPT_HTTPHEADER => [],
@@ -163,7 +161,6 @@ class CurlTransportTest extends TransportTestCase
             CURLOPT_URL => 'http://app.test/full/url',
             CURLOPT_HTTPHEADER => [],
             CURLOPT_CUSTOMREQUEST => 'GET',
-            CURLOPT_POSTFIELDS => null,
             CURLOPT_FILE => 'file_handle'
         ];
 

--- a/tests/UrlEncodedFormatterTest.php
+++ b/tests/UrlEncodedFormatterTest.php
@@ -75,4 +75,32 @@ class UrlEncodedFormatterTest extends TestCase
 
         $this->assertEquals('0', $headers['content-length'][0]);
     }
+
+    public function testFormatPutRequestWithInfileOption()
+    {
+        $fh = fopen(__DIR__ . '/test_file.txt', 'r');
+
+        $request = new Request();
+        $request->setMethod('PUT');
+        $request->setOptions([
+            CURLOPT_INFILE => $fh,
+            CURLOPT_INFILESIZE => filesize(__DIR__ . '/test_file.txt'),
+            CURLOPT_BINARYTRANSFER => true,
+            CURLOPT_PUT => 1,
+        ]);
+
+        $formatter = new UrlEncodedFormatter();
+        $formatter->format($request);
+
+        $headers = $request->getHeaders()->toArray();
+
+        $expectedHeaders = [
+            'content-type' =>
+                [
+                    0 => 'application/x-www-form-urlencoded; charset=UTF-8',
+                ],
+        ];
+
+        $this->assertEquals($expectedHeaders, $headers);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #189 