### PR TITLE
Error decoding CURL responses UTF-8 coded

### DIFF
--- a/src/JsonParser.php
+++ b/src/JsonParser.php
@@ -30,6 +30,11 @@ class JsonParser extends BaseObject implements ParserInterface
      */
     public function parse(Response $response)
     {
-        return Json::decode($response->getContent(), $this->asArray);
+        $content = $response->getContent();
+        if(mb_detect_encoding($content) == 'UTF-8') {
+            $content = preg_replace('/[^(\x20-\x7F)]*/','', $content);    
+        }
+        
+        return Json::decode($content, $this->asArray);
     }
 }


### PR DESCRIPTION
PHP json_decode() function throws JSON_ERROR_SYNTAX when decoding data via CURL that is in UTF-8 format. The breaks is caused by some characters in the beginning of the response, only visible when using htmlentities():  &iuml;&raquo;&iquest;.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | Decoding CURL responses in UTF-8 format.
