### PR TITLE
Enh #204

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 HTTP client extension Change Log
 2.0.13 under development
 ------------------------
 
-- no changes in this release.
+- Enh #204: added additional keys to `Message::getHeaders()` to make full http status line details available to `Client::getHeaders()` (ClintZeringue)
 
 
 2.0.12 October 08, 2019

--- a/src/Message.php
+++ b/src/Message.php
@@ -85,6 +85,9 @@ class Message extends Component
                         if (strpos($rawHeader, 'HTTP/') === 0) {
                             $parts = explode(' ', $rawHeader, 3);
                             $headerCollection->add('http-code', $parts[1]);
+                            $headerCollection->add('http-status-line',$rawHeader);
+                            $headerCollection->add('http-version',$parts[0]);
+                            $headerCollection->add('http-status-code-reason-phrase',trim($parts[1].' '.sizeof($parts)>2?trim($parts[2]):''));
                         } elseif (($separatorPos = strpos($rawHeader, ':')) !== false) {
                             $name = strtolower(trim(substr($rawHeader, 0, $separatorPos)));
                             $value = trim(substr($rawHeader, $separatorPos + 1));


### PR DESCRIPTION
Adds 3 new header keys to $headerCollection.
1. 'http-status-line': The full status line (ie. 'HTTP/1.1 200 OK')
2. 'http-version': The http version returned from the server (ie. 'HTTP/1.1')
3. 'http-status-code-reason-phrase': The status line without the HTTP version (ie. '200 OK')

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
