### PR TITLE
Added possibility to skip charset from header in `UrlEncodedFormatter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 HTTP client extension Change Log
 2.0.14 under development
 ------------------------
 
-- no changes in this release.
+- Enh #215: Added possibility to skip charset in header on `UrlEncodedFormatter::format()` (egorrishe)
 
 
 2.0.13 December 23, 2020

--- a/src/UrlEncodedFormatter.php
+++ b/src/UrlEncodedFormatter.php
@@ -56,7 +56,7 @@ class UrlEncodedFormatter extends BaseObject implements FormatterInterface
         }
 
         $charset = $this->charset === null ? Yii::$app->charset : $this->charset;
-        $charset = $charset ? 'charset=' . $charset : '';
+        $charset = $charset ? '; charset=' . $charset : '';
         $request->getHeaders()->set('Content-Type', 'application/x-www-form-urlencoded' . $charset);
 
         if (isset($content)) {

--- a/src/UrlEncodedFormatter.php
+++ b/src/UrlEncodedFormatter.php
@@ -56,7 +56,8 @@ class UrlEncodedFormatter extends BaseObject implements FormatterInterface
         }
 
         $charset = $this->charset === null ? Yii::$app->charset : $this->charset;
-        $request->getHeaders()->set('Content-Type', 'application/x-www-form-urlencoded; charset=' . $charset);
+        $charset = $charset ? 'charset=' . $charset : '';
+        $request->getHeaders()->set('Content-Type', 'application/x-www-form-urlencoded' . $charset);
 
         if (isset($content)) {
             $request->setContent($content);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes

Implementing API integration, I faced with case when API works properly only with header: 
`Content-Type: application/x-www-form-urlencoded`
But default header (with charset) works unexpectedly. I.e. :
`Content-Type: application/x-www-form-urlencoded; charset=UTF-8`

So I suggest to add possibility to skip charset.

Of course, it's possible to achieve the same goal and without this PR.
In my project I've override `UrlEncodedFormatter` with custom class and used it.

But such possibility from the box is much clearer. 
Besides that it's really tiny PR.