### PR TITLE
Parse content when it is not an empty string which fixes #224

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 HTTP client extension Change Log
 2.0.15 under development
 ------------------------
 
-- no changes in this release.
+- Bug #224: Parse content when it is not an empty string (pawmaster)
 
 
 2.0.14 August 09, 2021

--- a/src/Response.php
+++ b/src/Response.php
@@ -29,7 +29,7 @@ class Response extends Message
         $data = parent::getData();
         if ($data === null) {
             $content = $this->getContent();
-            if (!empty($content)) {
+            if (is_string($content) && strlen($content) > 0) {
                 $data = $this->getParser()->parse($this);
                 $this->setData($data);
             }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -114,16 +114,57 @@ HTML
         $this->assertEquals($expectedFormat, $response->getFormat());
     }
 
-    public function testParseBody()
+    /**
+     * Data provider for [[testParseBody()]]
+     * @return array test data
+     */
+    public function dataProviderParseBody()
+    {
+        return [
+            [
+                'name=value&age=30',
+                Client::FORMAT_URLENCODED,
+                ['name' => 'value', 'age' => '30'],
+            ],
+            [
+                '0',
+                Client::FORMAT_JSON,
+                0,
+            ],
+            [
+                '"0"',
+                Client::FORMAT_JSON,
+                '0',
+            ],
+            [
+                'null',
+                Client::FORMAT_JSON,
+                null,
+            ],
+            [
+                'false',
+                Client::FORMAT_JSON,
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderParseBody
+     *
+     * @param string $content
+     * @param string $format
+     * @param mixed $expected
+     */
+    public function testParseBody($content, $format, $expected)
     {
         $response = new Response([
             'client' => new Client(),
-            'format' => Client::FORMAT_URLENCODED,
+            'format' => $format,
         ]);
 
-        $content = 'name=value';
         $response->setContent($content);
-        $this->assertEquals(['name' => 'value'], $response->getData());
+        $this->assertSame($expected, $response->getData());
     }
 
     public function testGetStatusCode()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #224 

---

Can I just assuming type of `$content` must be either `null` or `false` or `string`?
