### PR TITLE
Fix #226: Fix error in debug panel due to PHP 8.1 deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 HTTP client extension Change Log
 ------------------------
 
 - Bug #224: Parse content when it is not an empty string (pawmaster)
+- Bug #226: Fix error in debug panel due to PHP 8.1 deprecation of implicit float to int conversion (lacek)
 
 
 2.0.14 August 09, 2021

--- a/src/debug/views/detail.php
+++ b/src/debug/views/detail.php
@@ -26,7 +26,7 @@ echo GridView::widget([
                 $timeInSeconds = $data['timestamp'] / 1000;
                 $millisecondsDiff = (int) (($timeInSeconds - (int) $timeInSeconds) * 1000);
 
-                return date('H:i:s.', $timeInSeconds) . sprintf('%03d', $millisecondsDiff);
+                return date('H:i:s.', (int) $timeInSeconds) . sprintf('%03d', $millisecondsDiff);
             },
             'headerOptions' => [
                 'class' => 'sort-numerical'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #226 
