### PR TITLE
Fixed `Response::getIsOk()` to include entire 2xx range

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -69,13 +69,14 @@ class Response extends Message
     }
 
     /**
-     * Checks if response status code is OK (status code = 20x)
+     * Checks if response status code is OK (status code = 2xx)
      * @return bool whether response is OK.
      * @throws Exception
      */
     public function getIsOk()
     {
-        return strncmp('20', $this->getStatusCode(), 2) === 0;
+        $statusCode = (int)$this->getStatusCode();
+        return $statusCode >= 200 && $statusCode < 300;
     }
 
     /**

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -199,8 +199,10 @@ HTML
     public function dataProviderIsOk()
     {
         return [
+            [100, false],
             [200, true],
             [201, true],
+            [226, true],
             [400, false],
         ];
     }


### PR DESCRIPTION
Fixed `\yii\httpclient\Response::getIsOk()` to include entire [2xx response code range](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#successful_responses).

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
