### PR TITLE
Fix `@var` annotation for `Response::$statusCode` and `@return` annotation for `Response::getStatusCode()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Yii Framework 2 HTTP client extension Change Log
 - Bug #253: Fixed `curl_close()` and `curl_multi_close()` deprecation since PHP 8.5 (samdark)
 - Enh #255: Applying Yii2 coding standards (@s1lver)
 - Enh #255: Raise min version to PHP 7.4 (@s1lver)
+- Bug #258: Fix `@var` annotation for `Response::$statusCode` and `@return` annotation for `Response::getStatusCode()` (@mspirkov)
 
 2.0.16 February 13, 2025
 ------------------------

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -661,12 +661,6 @@ parameters:
 			path: src/Response.php
 
 		-
-			message: '#^Method yii\\httpclient\\Response\:\:getStatusCode\(\) should return string but returns string\|null\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Response.php
-
-		-
 			message: '#^Method yii\\httpclient\\StreamTransport\:\:composeContextOptions\(\) has parameter \$options with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -1052,12 +1046,6 @@ parameters:
 
 		-
 			message: '#^Method yiiunit\\extensions\\httpclient\\ResponseTest\:\:dataProviderDetectFormatByHeaders\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/ResponseTest.php
-
-		-
-			message: '#^Method yiiunit\\extensions\\httpclient\\ResponseTest\:\:dataProviderIsOk\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: tests/ResponseTest.php

--- a/src/Response.php
+++ b/src/Response.php
@@ -15,7 +15,7 @@ use yii\web\HeaderCollection;
  * Response represents HTTP request response.
  *
  * @property-read bool $isOk Whether response is OK.
- * @property-read string $statusCode Status code.
+ * @property-read string|null $statusCode Status code.
  *
  * @author Paul Klimov <klimov.paul@gmail.com>
  * @since 2.0
@@ -56,7 +56,7 @@ class Response extends Message
     /**
      * Returns status code.
      * @throws Exception on failure.
-     * @return string status code.
+     * @return string|null status code.
      */
     public function getStatusCode()
     {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -171,16 +171,13 @@ HTML
     {
         $response = new Response();
 
-        $statusCode = 123;
+        $statusCode = '123';
         $response->setHeaders(['http-code' => $statusCode]);
-        $this->assertEquals($statusCode, $response->getStatusCode());
+        $this->assertSame($statusCode, $response->getStatusCode());
 
-        $statusCode = 123;
-        $response->setHeaders(['http-code' => [
-            $statusCode + 10,
-            $statusCode,
-        ]]);
-        $this->assertEquals($statusCode, $response->getStatusCode());
+        $statusCode = '123';
+        $response->setHeaders(['http-code' => ['133', $statusCode]]);
+        $this->assertSame($statusCode, $response->getStatusCode());
     }
 
     public function testUnableToGetStatusCode(): void
@@ -194,31 +191,28 @@ HTML
 
     /**
      * Data provider for [[testIsOk()]]
-     * @return array test data.
+     * @return list<array{string, bool}> test data.
      */
     public function dataProviderIsOk(): array
     {
         return [
-            [100, false],
-            [200, true],
-            [201, true],
-            [226, true],
-            [400, false],
+            ['100', false],
+            ['200', true],
+            ['201', true],
+            ['226', true],
+            ['400', false],
         ];
     }
 
     /**
      * @dataProvider dataProviderIsOk
      * @depends      testGetStatusCode
-     *
-     * @param int $statusCode
-     * @param bool $isOk
      */
-    public function testIsOk($statusCode, $isOk): void
+    public function testIsOk(string $statusCode, bool $isOk): void
     {
         $response = new Response();
         $response->setHeaders(['http-code' => $statusCode]);
-        $this->assertEquals($isOk, $response->getIsOk());
+        $this->assertSame($isOk, $response->getIsOk());
     }
 
     public function testParseCookieHeader(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
