### PR TITLE
Fix #267: Fix `@property` annotations in `Client`, `Message`, `Request` and `HttpClientPanel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 HTTP client extension Change Log
 2.0.18 under development
 ------------------------
 
-- Bug #TBD: Fix `@property` annotations in `Client`, `Message`, `Request` and `HttpClientPanel` (@mspirkov)
+- Bug #267: Fix `@property` annotations in `Client`, `Message`, `Request` and `HttpClientPanel` (@mspirkov)
 
 2.0.17 May 25, 2026
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 HTTP client extension Change Log
 2.0.18 under development
 ------------------------
 
-- no changes in this release.
+- Bug #TBD: Fix `@property` annotations in `Client`, `Message`, `Request` and `HttpClientPanel` (@mspirkov)
 
 2.0.17 May 25, 2026
 -------------------

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,12 @@
 parameters:
 	ignoreErrors:
 		-
+			message: '#^Class yii\\httpclient\\Client has PHPDoc tag @property for property \$transport with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Client.php
+
+		-
 			message: '#^Method yii\\httpclient\\Client\:\:afterSend\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -211,7 +217,7 @@ parameters:
 			path: src/Client.php
 
 		-
-			message: '#^Parameter \#1 \$type of static method yii\\BaseYii\<yii\\web\\IdentityInterface\>\:\:createObject\(\) expects array\{class\?\: class\-string\<mixed\>, __class\?\: class\-string\<mixed\>\}\|\(callable\(\)\: mixed\)\|class\-string\<mixed\>, array\|\(callable\(\)\: mixed\)\|string given\.$#'
+			message: '#^Parameter \#1 \$type of static method yii\\BaseYii\<yii\\web\\IdentityInterface\>\:\:createObject\(\) expects array\{class\?\: class\-string\<mixed\>, __class\?\: class\-string\<mixed\>, \.\.\.\}\|\(callable\(\)\: mixed\)\|class\-string\<mixed\>, array\|\(callable\(\)\: mixed\)\|string given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Client.php
@@ -367,6 +373,18 @@ parameters:
 			path: src/Message.php
 
 		-
+			message: '#^Class yii\\httpclient\\Message has PHPDoc tag @property for property \$headers with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Message.php
+
+		-
+			message: '#^Class yii\\httpclient\\Message has PHPDoc tag @property for property \$headers with no value type specified in iterable type array\|yii\\web\\HeaderCollection\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Message.php
+
+		-
 			message: '#^If condition is always true\.$#'
 			identifier: if.alwaysTrue
 			count: 2
@@ -433,12 +451,6 @@ parameters:
 			path: src/Message.php
 
 		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: src/Message.php
-
-		-
 			message: '#^Strict comparison using \!\=\= between string and null will always evaluate to true\.$#'
 			identifier: notIdentical.alwaysTrue
 			count: 1
@@ -463,9 +475,15 @@ parameters:
 			path: src/Request.php
 
 		-
-			message: '#^Class yii\\httpclient\\Request has PHPDoc tag @property for property \$url with no value type specified in iterable type array\.$#'
+			message: '#^Class yii\\httpclient\\Request has PHPDoc tag @property for property \$options with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
+			path: src/Request.php
+
+		-
+			message: '#^Class yii\\httpclient\\Request has PHPDoc tag @property for property \$url with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 2
 			path: src/Request.php
 
 		-
@@ -765,6 +783,24 @@ parameters:
 		-
 			message: '#^Cannot call method filterMessages\(\) on array\|string\|yii\\debug\\LogTarget\.$#'
 			identifier: method.nonObject
+			count: 1
+			path: src/debug/HttpClientPanel.php
+
+		-
+			message: '#^Class yii\\httpclient\\debug\\HttpClientPanel has PHPDoc tag @property for property \$httpClient with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/debug/HttpClientPanel.php
+
+		-
+			message: '#^Class yii\\httpclient\\debug\\HttpClientPanel has PHPDoc tag @property\-read for property \$methods with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/debug/HttpClientPanel.php
+
+		-
+			message: '#^Class yii\\httpclient\\debug\\HttpClientPanel has PHPDoc tag @property\-read for property \$types with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/debug/HttpClientPanel.php
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -16,8 +16,8 @@ use yii\helpers\StringHelper;
 /**
  * Client provide high level interface for HTTP requests execution.
  *
- * @property Transport $transport HTTP message transport instance. Note that the type of this property differs
- * in getter and setter. See [[getTransport()]] and [[setTransport()]] for details.
+ * @property-read Transport $transport HTTP message transport instance.
+ * @property-write Transport|array|string $transport HTTP message transport.
  *
  * @author Paul Klimov <klimov.paul@gmail.com>
  * @since 2.0

--- a/src/Message.php
+++ b/src/Message.php
@@ -19,12 +19,13 @@ use Yii;
  * Message represents a base HTTP message.
  *
  * @property string $content Raw body.
- * @property CookieCollection|Cookie[] $cookies The cookie collection. Note that the type of this property
- * differs in getter and setter. See [[getCookies()]] and [[setCookies()]] for details.
+ * @property-read CookieCollection|Cookie[] $cookies The cookie collection.
+ * @property-write CookieCollection|Cookie[]|array $cookies Cookie collection or cookies list.
  * @property mixed $data Content data fields.
  * @property string $format Body format name.
- * @property HeaderCollection $headers The header collection. Note that the type of this property differs in
- * getter and setter. See [[getHeaders()]] and [[setHeaders()]] for details.
+ * @property-read HeaderCollection $headers The header collection.
+ * @property-write array|HeaderCollection $headers Headers collection or headers list in format: [headerName
+ * => headerValue].
  *
  * @author Paul Klimov <klimov.paul@gmail.com>
  * @since 2.0

--- a/src/Request.php
+++ b/src/Request.php
@@ -17,10 +17,12 @@ use yii\helpers\FileHelper;
  *
  * @property string $fullUrl Full target URL.
  * @property string $method Request method.
- * @property array<array-key, mixed> $options Request options.
+ * @property array $options Request options.
  * @property resource $outputFile
- * @property string|array|null $url Target URL or URL parameters. Note that the type of this property differs
- * in getter and setter. See [[getUrl()]] and [[setUrl()]] for details.
+ * @property-read string|array|null $url Target URL or URL parameters.
+ * @property-write string|array $url Use a string to represent a URL (e.g. `http://some-domain.com`,
+ * `item/list`), or an array to represent a URL with query parameters (e.g. `['item/list', 'param1' =>
+ * 'value1']`).
  *
  * @author Paul Klimov <klimov.paul@gmail.com>
  * @since 2.0

--- a/src/debug/HttpClientPanel.php
+++ b/src/debug/HttpClientPanel.php
@@ -17,10 +17,10 @@ use Yii;
 /**
  * Debugger panel that collects and displays HTTP requests performed.
  *
- * @property \yii\httpclient\Client $httpClient Note that the type of this property differs in getter and
- * setter. See [[getHttpClient()]] and [[setHttpClient()]] for details.
- * @property-read array<string,string> $methods
- * @property-read array<string,string> $types
+ * @property-read \yii\httpclient\Client $httpClient
+ * @property-write array $httpClient
+ * @property-read array $methods
+ * @property-read array $types
  *
  * @author Paul Klimov <klimov.paul@gmail.com>
  * @since 2.0


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

See: https://github.com/yiisoft/yii2/pull/21042